### PR TITLE
Modify generation wallet-config if missing

### DIFF
--- a/wallet/config/config.go
+++ b/wallet/config/config.go
@@ -40,10 +40,10 @@ type DefaultQuery struct {
 func InitConfig() {
 	newConf := false
 
-	conf.Version = "0.5.0"
+	conf.Version = config.GetConfig().Version
 	conf.CultureInfo = "en-US"
 	conf.Option.DisableMining = true
-	conf.Option.PoolAddress = "test.xdag.org:13656"
+	conf.Option.PoolAddress = "xdag.org:13656"
 
 	pwd, _ := os.Executable()
 	pwd, _ = path.Split(pwd)

--- a/wallet/config/config.go
+++ b/wallet/config/config.go
@@ -40,7 +40,7 @@ type DefaultQuery struct {
 func InitConfig() {
 	newConf := false
 
-	conf.Version = config.GetConfig().Version
+	conf.Version = "0.5.3"
 	conf.CultureInfo = "en-US"
 	conf.Option.DisableMining = true
 	conf.Option.PoolAddress = "xdag.org:13656"


### PR DESCRIPTION
Not certain that config.GetConfig().Version is good on line 43. Else should be 👍 

conf.Version = "0.5.3"