### PR TITLE
Fix in case of missing wallet-config.json

### DIFF
--- a/wallet/wallet-config.json
+++ b/wallet/wallet-config.json
@@ -5,10 +5,10 @@
     "specified_pool_address": null,
     "is_test_net": false,
     "disable_mining": true,
-    "pool_address": "xdagmine.com:13654",
+    "pool_address": "xdag.org:13656",
     "testnet_api_url": ""
   },
-  "version": "0.5.3",
+  "version": "0.5.5",
   "culture_info": "en-US",
   "addresses": [
   ],


### PR DESCRIPTION
 if the wallet-config.json file is missing, the wallet generates a new file with 2 problems: 

1/ The pool test.xdag.org does not exist anymore
2/ The version number is wrong (0.5.0).

I will also propose a fix for these 2 problems.

For the pool, I will follow the recommendations made by team and put xdarg.org instead of xdagmine.com