### PR TITLE
Fix issues when wallet-config.json is missing.

### DIFF
--- a/wallet/config/config.go
+++ b/wallet/config/config.go
@@ -40,10 +40,10 @@ type DefaultQuery struct {
 func InitConfig() {
 	newConf := false
 
-	conf.Version = "0.5.0"
+	conf.Version = "0.5.5"
 	conf.CultureInfo = "en-US"
 	conf.Option.DisableMining = true
-	conf.Option.PoolAddress = "test.xdag.org:13656"
+	conf.Option.PoolAddress = "xdag.org:13656"
 
 	pwd, _ := os.Executable()
 	pwd, _ = path.Split(pwd)


### PR DESCRIPTION
 if the wallet-config.json file is missing, the wallet generates a new file with 2 problems: 

1/ The pool test.xdag.org does not exist anymore
2/ The version number was wrong (0.5.0).

I will also propose a fix for these 2 problems.

For the pool, I will follow the recommendations made by team and put xdarg.org instead of xdagmine.com